### PR TITLE
:art: html2wxml插件升级到1.4.0版本

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
     },
     "plugins": {
         "htmltowxml": {
-            "version": "1.3.1",
+            "version": "1.4.0",
             "provider": "wxa51b9c855ae38f3c"
         }
     },


### PR DESCRIPTION
1.3.1版本将在5月15日停止使用 请知悉